### PR TITLE
Fix CVSS score and privilege guidance

### DIFF
--- a/skills/triage/references/ai-slop.md
+++ b/skills/triage/references/ai-slop.md
@@ -70,10 +70,12 @@ on YesWeHack.
   flag any Environmental/Temporal metrics the hunter set themselves
   (those are the program's to weigh; setting them inflates the score).
   The classic LLM pattern is the "max-severity" vector
-  (`AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` = 9.8) defaulted onto a bug
+  (`AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` = 10.0) defaulted onto a bug
   it doesn't fit. Common mismatches: `PR:N` claimed when auth has a
-  real gate (paid tier, admin invite, org membership) — `PR:N` is
-  only correct when self-registration is open; `UI:N` claimed when
+  real gate (paid tier, admin invite, org membership, or a basic user
+  account). Open self-registration does not make authenticated access
+  `PR:N`; use `PR:L` if the exploit depends on the account's privileges.
+  Another common mismatch is `UI:N` claimed when
   the victim must click / paste / load; `S:C` claimed without an
   actual trust boundary crossing; `AC:L` claimed when the resource ID
   is a non-guessable UUID (that's `AC:H`). Check each metric against

--- a/skills/write/SKILL.md
+++ b/skills/write/SKILL.md
@@ -182,8 +182,9 @@ are slop-prone, so verify them in your review:
 - Sections present but empty / "TBD" / "see PoC".
 - Steps that say "trigger the vulnerability" — not atomic.
 - Impact section longer than the PoC.
-- Severity vector that doesn't match the preconditions (e.g., `PR:L`
-  claimed when self-registration is open and `PR:N` applies).
+- Severity vector that doesn't match the preconditions (e.g., `PR:N`
+  claimed even though the exploit requires an authenticated basic user.
+  Open self-registration does not remove that privilege requirement.)
 - Repro steps that reference a screenshot instead of giving the URL.
 
 Watch your own output for AI-slop patterns (theoretical impact,


### PR DESCRIPTION
The example vector uses `S:C`, so it scores 10.0 rather than 9.8 in the [FIRST calculator](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H).

The self-registration examples also had `PR:N` and `PR:L` backwards. FIRST defines the metrics as:

> **PR:N:** "The attacker is unauthorized prior to attack"
>
> **PR:L:** "The attacker requires privileges that provide basic user capabilities"

Source: [CVSS v3.1 specification](https://www.first.org/cvss/v3.1/specification-document#2-1-3-Privileges-Required-PR)

If exploitation needs the privileges of a signed-in basic account, open registration does not remove that requirement.